### PR TITLE
add custom handling of the conditions array 

### DIFF
--- a/MMM-Config.converter.js
+++ b/MMM-Config.converter.js
@@ -1,0 +1,75 @@
+/* converter */
+function converter(config_data, direction){
+  let source_types=['out', 'err', 'code', 'noti']
+	if (direction == 'toForm'){ // convert FROM native object format to form schema array format
+		//console.log("there are "+config_data.buttons.length+" buttons")
+		// config format is an object, need an extendable array
+		config_data.buttons.forEach(button =>{
+			// for each key (morning, afternoon, eventing, date..., weather )
+			// push an object onto the 'array '
+			let nc = []
+			// the object must match the custom schema definition
+			//console.log("there are "+button.conditions.length+" conditions")
+			button.conditions.forEach(source_c =>{
+			  let new_c = {}
+			  new_c.source = source_c.source
+			  if(source_c.source=='code'){
+			  	new_c.typecode=source_c.type
+			  	new_c.valuecode = source_c.value
+			  } else {
+			  	new_c.typestring=source_c.type
+			  	new_c.valuestring=source_c.value
+					if(source_c.source === 'noti'){
+					 	new_c.notistring = source_c.notification
+					}
+			  }
+			  new_c.icon = source_c.icon || null
+			  new_c.imgIcon = source_c.imgIcon || null
+			  new_c.classes =  source_c.classes || null
+
+				// save the new field structure in the array
+			  nc.push(new_c)
+			})
+			if(nc.length>0){
+				//console.log("there are "+nc.length+" new conditions")
+				button.conditions = JSON.parse(JSON.stringify(nc))
+			}
+		})
+
+		return config_data
+	}
+	else if (direction == 'toConfig'){  // convert TO native object from form array
+
+		// config format is a modified in array, need fix object array
+		config_data.buttons.forEach(button =>{
+			// for each key (morning, afternoon, eventing, date..., weather )
+			// push an object onto the 'array '
+			let nc = []
+			// the object must match the custom schema definition
+			button.conditions.forEach(source_c =>{
+				let new_c = {}
+				new_c.source = source_c.source
+				new_c.value  = source_c.valuestring
+				if(new_c.source =='noti'){
+					new_c.notification = source_c.notistring
+				} else if(source_c.source==='code'){
+					new_c.value  = source_c.valuecode
+					new_c.type=source_c.typecode
+				} else {
+					new_c.value  = source_c.valuestring
+					new_c.type=source_c.typestring
+				}
+				new_c.icon = source_c.icon || null
+				if(source_c.icon && source_c.icon.includes('/'))
+					new_c.imgIcon = source_c.icon
+				nc.push(new_c)
+			})
+			if(nc.length){
+				button.conditions=JSON.parse(JSON.stringify(nc))
+			}
+		})
+		return config_data
+	}
+
+}
+exports.converter=converter

--- a/MMM-Config.converter.js
+++ b/MMM-Config.converter.js
@@ -15,7 +15,7 @@ function converter(config_data, direction){
 			  new_c.source = source_c.source
 			  if(source_c.source=='code'){
 			  	new_c.typecode=source_c.type
-			  	new_c.valuecode = source_c.value
+			  	new_c.valuecode=source_c.value
 			  } else {
 			  	new_c.typestring=source_c.type
 			  	new_c.valuestring=source_c.value
@@ -52,6 +52,7 @@ function converter(config_data, direction){
 				if(new_c.source === 'noti'){
 					new_c.notification = source_c.notistring
 					new_c.type=source_c.typestring
+					new_c,value = source_c.valuestring
 				} else if(source_c.source==='code'){
 					new_c.value = source_c.valuecode
 					new_c.type=source_c.typecode

--- a/MMM-Config.converter.js
+++ b/MMM-Config.converter.js
@@ -49,14 +49,14 @@ function converter(config_data, direction){
 			button.conditions.forEach(source_c =>{
 				let new_c = {}
 				new_c.source = source_c.source
-				new_c.value  = source_c.valuestring
-				if(new_c.source =='noti'){
+				if(new_c.source === 'noti'){
 					new_c.notification = source_c.notistring
+					new_c.type=source_c.typestring
 				} else if(source_c.source==='code'){
-					new_c.value  = source_c.valuecode
+					new_c.value = source_c.valuecode
 					new_c.type=source_c.typecode
 				} else {
-					new_c.value  = source_c.valuestring
+					new_c.value = source_c.valuestring
 					new_c.type=source_c.typestring
 				}
 				new_c.icon = source_c.icon || null

--- a/MMM-Config.schema.json
+++ b/MMM-Config.schema.json
@@ -1,0 +1,542 @@
+{
+  "schema": {
+    "MMM-TouchButton": {
+      "type": "object",
+      "title": "properties for MMM-TouchButton",
+      "properties": {
+        "module": {
+          "type": "string",
+          "title": "module",
+          "default": "MMM-TouchButton",
+          "readonly": true
+        },
+        "disabled": {
+          "type": "boolean",
+          "title": "disabled",
+          "default": false
+        },
+        "position": {
+          "type": "string",
+          "title": "module position",
+          "readonly": "true"
+        },
+        "classes": {
+          "type": "string",
+          "title": "classes",
+          "default": ""
+        },
+        "header": {
+          "type": "string",
+          "title": "header",
+          "default": ""
+        },
+        "hiddenOnStartup": {
+          "type": "boolean",
+          "title": "hiddenOnStartup",
+          "default": false
+        },
+        "configDeepMerge": {
+          "type": "boolean",
+          "title": "configDeepMerge",
+          "default": false
+        },
+        "order": {
+          "type": "string",
+          "title": "order",
+          "default": "*"
+        },
+        "inconfig": {
+          "type": "string",
+          "title": "inconfig",
+          "default": "0"
+        },
+        "index": {
+          "type": "integer"
+        },
+        "animateIn": {
+          "type": "string",
+          "enum": [
+            "None",
+            "bounce",
+            "flash",
+            "pulse",
+            "rubberBand",
+            "shakeX",
+            "shakeY",
+            "headShake",
+            "swing",
+            "tada",
+            "wobble",
+            "jello",
+            "heartBeat",
+            "backInDown",
+            "backInLeft",
+            "backInRight",
+            "backInUp",
+            "bounceIn",
+            "bounceInDown",
+            "bounceInLeft",
+            "bounceInRight",
+            "bounceInUp",
+            "fadeIn",
+            "fadeInDown",
+            "fadeInDownBig",
+            "fadeInLeft",
+            "fadeInLeftBig",
+            "fadeInRight",
+            "fadeInRightBig",
+            "fadeInUp",
+            "fadeInUpBig",
+            "fadeInTopLeft",
+            "fadeInTopRight",
+            "fadeInBottomLeft",
+            "fadeInBottomRight",
+            "flip",
+            "flipInX",
+            "flipInY",
+            "lightSpeedInRight",
+            "lightSpeedInLeft",
+            "rotateIn",
+            "rotateInDownLeft",
+            "rotateInDownRight",
+            "rotateInUpLeft",
+            "rotateInUpRight",
+            "jackInTheBox",
+            "rollIn",
+            "zoomIn",
+            "zoomInDown",
+            "zoomInLeft",
+            "zoomInRight",
+            "zoomInUp",
+            "slideInDown",
+            "slideInLeft",
+            "slideInRight",
+            "slideInUp"
+          ]
+        },
+        "animateOut": {
+          "type": "string",
+          "enum": [
+            "None",
+            "backOutDown",
+            "backOutLeft",
+            "backOutRight",
+            "backOutUp",
+            "bounceOut",
+            "bounceOutDown",
+            "bounceOutLeft",
+            "bounceOutRight",
+            "bounceOutUp",
+            "fadeOut",
+            "fadeOutDown",
+            "fadeOutDownBig",
+            "fadeOutLeft",
+            "fadeOutLeftBig",
+            "fadeOutRight",
+            "fadeOutRightBig",
+            "fadeOutUp",
+            "fadeOutUpBig",
+            "fadeOutTopLeft",
+            "fadeOutTopRight",
+            "fadeOutBottomRight",
+            "fadeOutBottomLeft",
+            "flipOutX",
+            "flipOutY",
+            "lightSpeedOutRight",
+            "lightSpeedOutLeft",
+            "rotateOut",
+            "rotateOutDownLeft",
+            "rotateOutDownRight",
+            "rotateOutUpLeft",
+            "rotateOutUpRight",
+            "hinge",
+            "rollOut",
+            "zoomOut",
+            "zoomOutDown",
+            "zoomOutLeft",
+            "zoomOutRight",
+            "zoomOutUp",
+            "slideOutDown",
+            "slideOutLeft",
+            "slideOutRight",
+            "slideOutUp"
+          ]
+        },
+        "config": {
+          "type": "object",
+          "title": "config",
+          "properties": {
+            "animationSpeed": {
+              "type": "integer"
+            },
+            "classes": {
+              "type": "string"
+            },
+            "buttons": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "imgIcon": {
+                    "type": "string"
+                  },
+                  "command": {
+                    "type": "string"
+                  },
+                  "args": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "notification": {
+                    "type": "string"
+                  },
+                  "payload": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      },
+                      "payload": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "profiles": {
+                    "type": "string"
+                  },
+                  "classes": {
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string",
+                          "enum":[
+                            "out",
+                            "err",
+                            "code"
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum":[
+                            "lt",
+                            "le",
+                            "gt",
+                            "ge",
+                            "eq",
+                            "incl",
+                            "mt"
+                          ]
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "icon": {
+                          "type": "string"
+                        },
+                        "jsonpath": {
+                          "type": "string"
+                        },
+                        "imgIcon": {
+                          "type": "string"
+                        },
+                        "classes": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "addEmptyTitle": {
+              "type": "boolean"
+            },
+            "refreshOnNotification": {
+              "type": "boolean"
+            },
+            "refreshOnlyIfValueChanged": {
+              "type": "boolean"
+            },
+            "notificationDelay": {
+              "type": "integer"
+            },
+            "notificationsAtStart": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "form": [
+    {
+      "key": "MMM-TouchButton.disabled",
+      "htmlClass": "disabled_checkbox",
+      "description": "when checked the module will not be used by MagicMirror<br> but will remain in config.js if already present"
+    },
+    {
+      "key": "MMM-TouchButton.position",
+      "description": "use Module Positions section below to set or change"
+    },
+    {
+      "key": "MMM-TouchButton.header",
+      "description": "header to use for this module"
+    },
+    {
+      "key": "MMM-TouchButton.hiddenOnStartup",
+      "description": "Set module as being hidden on startup. This field is optional."
+    },
+    {
+      "key": "MMM-TouchButton.configDeepMerge",
+      "description": "Allow to merge with internal configuration in deep"
+    },
+    {
+      "key": "MMM-TouchButton.classes",
+      "description": "css classes to use for this module, beyond what MM provides"
+    },
+    {
+      "key": "MMM-TouchButton.order",
+      "type": "hidden"
+    },
+    {
+      "key": "MMM-TouchButton.inconfig",
+      "type": "hidden"
+    },
+    {
+      "key": "MMM-TouchButton.animateIn",
+      "title": "animateIn",
+      "description": "select one of these to change the behavior when the module is shown"
+    },
+    {
+      "key": "MMM-TouchButton.animateOut",
+      "title": "animateOut",
+      "description": "select one of these to change the behavior when the module is hidden"
+    },
+    {
+      "key": "MMM-TouchButton.index",
+      "type": "hidden"
+    },
+    {
+      "type": "fieldset",
+      "title": "config",
+      "htmlClass": "moduleConfig",
+      "items": [
+        {
+          "type": "button",
+          "title": "Open module readme",
+          "htmlClass": "repo_button",
+          "onClick": "(evt,node)=>{let siblings=$(evt.target).siblings('.readme_url');let element=siblings.toArray()[0];let url=element.innerText;let pos=$(evt.target).offset();process_readme(url,pos)}"
+        },
+        {
+          "type": "button",
+          "htmlClass": "hidden readme_url",
+          "title": "http://localhost:xxxx/modules/MMM-TouchButton/README.md"
+        },
+        {
+          "title": "animationSpeed",
+          "key": "MMM-TouchButton.config.animationSpeed"
+        },
+        {
+          "title": "classes",
+          "key": "MMM-TouchButton.config.classes"
+        },
+        {
+          "type": "array",
+          "title": "buttons",
+          "deleteCurrent": false,
+          "items": {
+            "type": "fieldset",
+            "title": "buttons",
+            "items": [
+              {
+                "title": "name",
+                "key": "MMM-TouchButton.config.buttons[].name"
+              },
+              {
+                "title": "icon",
+                "key": "MMM-TouchButton.config.buttons[].icon"
+              },
+              {
+                "title": "imgIcon",
+                "key": "MMM-TouchButton.config.buttons[].imgIcon"
+              },
+              {
+                "title": "command",
+                "key": "MMM-TouchButton.config.buttons[].command"
+              },
+              {
+                "title": "args",
+                "key": "MMM-TouchButton.config.buttons[].args"
+              },
+              {
+                "title": "title",
+                "key": "MMM-TouchButton.config.buttons[].title"
+              },
+              {
+                "title": "notification",
+                "key": "MMM-TouchButton.config.buttons[].notification"
+              },
+              {
+                "type": "fieldset",
+                "title": "payload",
+                "items": [
+                  {
+                    "title": "type",
+                    "key": "MMM-TouchButton.config.buttons[].payload.type"
+                  },
+                  {
+                    "type": "array",
+                    "title": "payload",
+                    "deleteCurrent": false,
+                    "items": [
+                      {
+                        "title": "payload {{idx}}",
+                        "key": "MMM-TouchButton.config.buttons[].payload.payload[]",
+                        "type": "ace",
+                        "aceMode": "json",
+                        "aceTheme": "twilight",
+                        "width": "100%",
+                        "height": "100px"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "profiles",
+                "key": "MMM-TouchButton.config.buttons[].profiles"
+              },
+              {
+                "title": "classes",
+                "key": "MMM-TouchButton.config.buttons[].classes"
+              },
+              {
+                "type": "array",
+                "title": "conditions",
+                "deleteCurrent": false,
+                "items": {
+                  "type": "fieldset",
+                  "title": "conditions",
+                  "items": [
+                    {
+                      "title": "source",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].source"
+                    },
+                    {
+                      "title": "type",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].type"
+                    },
+                    {
+                      "title": "value",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].value"
+                    },
+                    {
+                      "title": "icon",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].icon"
+                    },
+                    {
+                      "title": "jsonpath",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].jsonpath"
+                    },
+                    {
+                      "title": "imgIcon",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].imgIcon"
+                    },
+                    {
+                      "title": "classes",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].classes"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "draggable": false
+        },
+        {
+          "title": "addEmptyTitle",
+          "key": "MMM-TouchButton.config.addEmptyTitle"
+        },
+        {
+          "title": "refreshOnNotification",
+          "key": "MMM-TouchButton.config.refreshOnNotification"
+        },
+        {
+          "title": "refreshOnlyIfValueChanged",
+          "key": "MMM-TouchButton.config.refreshOnlyIfValueChanged"
+        },
+        {
+          "title": "notificationDelay",
+          "key": "MMM-TouchButton.config.notificationDelay"
+        },
+        {
+          "type": "array",
+          "title": "notificationsAtStart",
+          "deleteCurrent": false,
+          "items": [
+            {
+              "title": "notificationsAtStart {{idx}}",
+              "key": "MMM-TouchButton.config.notificationsAtStart[]"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "value": {
+    "disabled": true,
+    "module": "MMM-TouchButton",
+    "position": "none",
+    "order": "*",
+    "inconfig": "0",
+    "config": {
+      "animationSpeed": 0,
+      "classes": null,
+      "buttons": [
+        {
+          "name": "",
+          "icon": "",
+          "imgIcon": null,
+          "command": "",
+          "args": "",
+          "title": null,
+          "notification": "",
+          "payload": {
+            "type": "",
+            "payload": {}
+          },
+          "profiles": null,
+          "classes": null,
+          "conditions": [
+          ]
+        }
+      ],
+      "addEmptyTitle": false,
+      "refreshOnNotification": true,
+      "refreshOnlyIfValueChanged": true,
+      "notificationDelay": 3000,
+      "notificationsAtStart": []
+    },
+    "animateIn": "none",
+    "animateOut": "none"
+  }
+}

--- a/MMM-Config.schema.json
+++ b/MMM-Config.schema.json
@@ -169,9 +169,6 @@
             "animationSpeed": {
               "type": "integer"
             },
-            "classes": {
-              "type": "string"
-            },
             "buttons": {
               "type": "array",
               "items": {
@@ -228,28 +225,38 @@
                           "enum":[
                             "out",
                             "err",
-                            "code"
+                            "code",
+                            "noti"
                           ]
                         },
-                        "type": {
+                        "typestring": {
                           "type": "string",
                           "enum":[
-                            "lt",
-                            "le",
-                            "gt",
-                            "ge",
                             "eq",
                             "incl",
                             "mt"
                           ]
                         },
-                        "value": {
+                        "typecode": {
+                          "type": "integer",
+                          "enum":[
+                            "lt",
+                            "le",
+                            "gt",
+                            "ge",
+                            "eq"
+                          ]
+                        },
+                        "notistring": {
                           "type": "string"
+                        },
+                        "valuestring": {
+                          "type": "string"
+                        },
+                        "valuecode": {
+                          "type": "integer"
                         },
                         "icon": {
-                          "type": "string"
-                        },
-                        "jsonpath": {
                           "type": "string"
                         },
                         "imgIcon": {
@@ -356,10 +363,6 @@
           "key": "MMM-TouchButton.config.animationSpeed"
         },
         {
-          "title": "classes",
-          "key": "MMM-TouchButton.config.classes"
-        },
-        {
           "type": "array",
           "title": "buttons",
           "deleteCurrent": false,
@@ -431,39 +434,82 @@
               },
               {
                 "type": "array",
-                "title": "conditions",
-                "deleteCurrent": false,
+                "title": "conditions for this button",
+                "deleteCurrent": true,
+                "draggable":true,
                 "items": {
                   "type": "fieldset",
-                  "title": "conditions",
+                  "title":"condition {{idx}}",
                   "items": [
                     {
-                      "title": "source",
-                      "key": "MMM-TouchButton.config.buttons[].conditions[].source"
+                      "title": "condition content source",
+                      "fieldHtmlClass":"source",
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].source",
+                      "onChange":"(evt,node)=>{let vf='notistring';let cl={'out':'string','err':'string','code':'code','noti':'string'};let value=evt.target.value;let selectedclass=cl[value];var parentElement=$(evt.target).closest('fieldset');Object.keys(cl).forEach(k=>{let target=parentElement.find('div[class$='+cl[k]+']');let style=(cl[k]===selectedclass?'Block':'none');target.css('display',style)});if(value!=='noti'){parentElement.find('div[class$='+vf+']').css('display','none');}}",
+                      "titleMap":{
+                            "out":"command output string",
+                            "err":"command error string",
+                            "code":"command return code",
+                            "noti":"notification string"
+                      }
+                    },
+                   {
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].notistring",
+                      "title":"condition notification string",
+                      "fieldHtmlClass":"value-noti-string",
+                      "description": "this is the received notification to check the payload",
+                      "required":true
                     },
                     {
-                      "title": "type",
-                      "key": "MMM-TouchButton.config.buttons[].conditions[].type"
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].typestring",
+                      "title":"compare type",
+                      "fieldHtmlClass":"compare_type-string",
+                      "titleMap":{
+                            "eq":"source string equals value",
+                            "incl":"source string includes value",
+                            "mt":"value string is a regex to match source against"
+                      },
+                      "description": "select the compare type for the value against the source"
                     },
                     {
-                      "title": "value",
-                      "key": "MMM-TouchButton.config.buttons[].conditions[].value"
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].typecode",
+                      "title":"compare type",
+                      "fieldHtmlClass":"compare_type-code",
+                      "titleMap":{
+                            "lt":"less than",
+                            "le":"less than or equal",
+                            "gt":"greater than",
+                            "ge":"greater than or equal",
+                            "eq":"equal"
+                      },
+                      "description": "select the compare type for the value against the source",
+                      "required":true
                     },
                     {
-                      "title": "icon",
-                      "key": "MMM-TouchButton.config.buttons[].conditions[].icon"
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].valuestring",
+                      "title":"condition compare value string",
+                      "fieldHtmlClass":"compare_value-format-string",
+                      "description": "this is the value used in the condition comparison",
+                      "required":true
                     },
                     {
-                      "title": "jsonpath",
-                      "key": "MMM-TouchButton.config.buttons[].conditions[].jsonpath"
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].valuecode",
+                      "title":"condition compare value number",
+                      "fieldHtmlClass":"compare_value-format-code",
+                      "description": "this is the value used in the condition comparison",
+                      "required":true
                     },
                     {
-                      "title": "imgIcon",
-                      "key": "MMM-TouchButton.config.buttons[].conditions[].imgIcon"
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].classes",
+                      "title":"the classes to apply to this button if the condition expression is true",
+                      "fieldHtmlClass":"condition_classes",
+                      "required":false
                     },
                     {
-                      "title": "classes",
-                      "key": "MMM-TouchButton.config.buttons[].conditions[].classes"
+                      "key": "MMM-TouchButton.config.buttons[].conditions[].icon",
+                      "title":"the icon name or path to icon file to apply to this button if the condition expression is true",
+                      "fieldHtmlClass":"condition_icon",
+                      "required":false
                     }
                   ]
                 }

--- a/MMM-Config_extension.css
+++ b/MMM-Config_extension.css
@@ -1,0 +1,5 @@
+/* css */
+
+.m_MMM-TouchButton [class$="---typecode"] , [class$="---valuecode"] , [class$="---notistring"] {
+	display:none;
+}

--- a/MMM-Config_extension.js
+++ b/MMM-Config_extension.js
@@ -1,0 +1,38 @@
+/* extension */
+
+$(document).on('form_loaded', function () {
+	// find all the elements of our when selection list and get the selected option in each
+	$('.m_MMM_TouchButton select[class$=".source"]  option:selected').each(
+		// process each
+		function(){
+			// get its selected option text
+			var selected_option_value=$(this).text(); //.text() contains the visible value from titlemap, .val() contains the enum value
+																							 // if no title map .text() and .val() are the same
+			// if its one of the special fields
+			//if(selected_option_value.endsWith('string') || selected_option_value.endsWith('code')){
+				let other = selected_option_value.endsWith('string')?"code":"string"
+				// look above the select to the next element that encloses select and the custom fields (fieldset)
+				// this is all one clause, just split over multiple lines for clarity
+				$(this).closest('fieldset')
+					// find below the fieldset to find the appropriate div with the right class,
+					.find('div[class$="'+selected_option_value+'"]')
+						// and set its display style property to block, previously set to display:none by MMM-Config.extension.css
+						.css('display','block')
+
+				if(selected_option_value!=='noti'){
+					$(this).closest('fieldset')
+					// find below the fieldset to find the appropriate div with the right class,
+					.find('div[class*="noti"]')
+						// and set its display style property to block, previously set to display:none by MMM-Config.extension.css
+						.css('display','none')
+				}
+
+				$(this).closest('fieldset')
+					// find below the fieldset to find the appropriate div with the right class,
+					.find('div[class$="'+other+'"]')
+						// and set its display style property to block, previously set to display:none by MMM-Config.extension.css
+						.css('display','none')
+			//}
+		}
+	)
+})


### PR DESCRIPTION
this needs the latest MMM-Config just updated.  this uses the class name of the fields to show/hide as approriate 
in the schema onchange handler for the source field. 

give it a wirl

css hides all fields
extension surfaces fields which match the incoming data on form load 
converter moves between config format and form format (using field with classes of string or code or noti to surface as required)
schema onchange updated to do the field exposure on change of source field